### PR TITLE
Use json format for cfn tags

### DIFF
--- a/cloudformation/slack-router-cfn-template.js
+++ b/cloudformation/slack-router-cfn-template.js
@@ -18,10 +18,10 @@ const Resources = {
     Properties: {
       Name: 'slack-router-api',
       ProtocolType: 'HTTP',
-      Tags: [
-        { Key: 'Name', Value: 'slack-router-api' },
-        { Key: 'Project', Value: 'slackbot' },
-      ],
+      Tags: {
+        "Name":"slack-router-api",
+        "Project":"slackbot-router"
+      }
     },
   },
   SlackToLambdaIntegration: {


### PR DESCRIPTION
cloudformation for some reason follows a different format for tagging the apigateway than standard. 