### PR TITLE
Deploy slack-router to production

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,4 +52,3 @@ workflows:
           branches:
             only:
             - master
-            

--- a/cloudformation/slack-router-cfn-template.js
+++ b/cloudformation/slack-router-cfn-template.js
@@ -18,10 +18,11 @@ const Resources = {
     Properties: {
       Name: 'slack-router-api',
       ProtocolType: 'HTTP',
-      Tags: [
-        { Key: 'Name', Value: 'slack-router-api' },
-        { Key: 'Project', Value: 'slackbot' },
-      ],
+      Tags: { 
+        'Name': 'slack-router-api',
+        'Tool': 'slackbot',
+        'Environment': cf.stackName
+      },
     },
   },
   SlackToLambdaIntegration: {
@@ -106,6 +107,13 @@ const lambda = new cf.shortcuts.Lambda({
         'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/slack-router-signing-secret'
       ),
     },
+    {
+      Effect: 'Allow',
+      Action: [
+        'sns:Publish'
+      ],
+      Resource: cf.sub('arn:aws:sns:${AWS::Region}:${AWS::AccountId}:*')
+    }
   ],
   Tags: [
     { Key: 'Name', Value: 'slack-router-lambda' },

--- a/src/command-help/cloudformation/command-help-cfn-template.js
+++ b/src/command-help/cloudformation/command-help-cfn-template.js
@@ -4,7 +4,7 @@ const Parameters = {
   BucketName: {
     Type: 'String',
     Description: 'Name of S3 bucket where Lambda code is saved',
-    Default: 'stork-us-east-1',
+    Default: 'slack-bot-commands',
   },
   GitSha: {
     Type: 'String',
@@ -25,7 +25,8 @@ const Resources = {
       ],
       Tags: [
         { Key: 'Name', Value: 'command-help-sns' },
-        { Key: 'Project', Value: 'slackbot' },
+        { Key: 'Tool', Value: 'slackbot' },
+        { Key: 'Environment', Value: cf.stackName },
       ],
     },
   },
@@ -45,7 +46,7 @@ const lambda = new cf.shortcuts.Lambda({
   Handler: 'src/command-help/command-help-lambda.handler',
   Code: {
     S3Bucket: cf.ref('BucketName'),
-    S3Key: cf.join('', ['bundles/slack-bots/', cf.ref('GitSha'), '.zip']),
+    S3Key: 'command-help.zip',
   },
   Runtime: 'nodejs12.x',
   Timeout: '60',

--- a/src/dir/cloudformation/dir-cfn-template.js
+++ b/src/dir/cloudformation/dir-cfn-template.js
@@ -25,7 +25,8 @@ const Resources = {
       ],
       Tags: [
         { Key: 'Name', Value: 'dir-sns' },
-        { Key: 'Project', Value: 'slackbot' },
+        { Key: 'Tool', Value: 'slackbot' },
+        { Key: 'Environment', Value: cf.stackName },
       ],
     },
   },
@@ -45,7 +46,7 @@ const lambda = new cf.shortcuts.Lambda({
   Handler: 'dir/dir-lambda.handler',
   Code: {
     S3Bucket: cf.ref('BucketName'),
-    S3Key: "dir.zip",
+    S3Key: 'dir.zip',
   },
   Environment: {
     Variables: {

--- a/src/guidelines/cloudformation/guidelines-cfn-template.js
+++ b/src/guidelines/cloudformation/guidelines-cfn-template.js
@@ -25,7 +25,8 @@ const Resources = {
       ],
       Tags: [
         { Key: 'Name', Value: 'guidelines-sns' },
-        { Key: 'Project', Value: 'slackbot' },
+        { Key: 'Tool', Value: 'slackbot' },
+        { Key: 'Environment', Value: cf.stackName },
       ],
     },
   },
@@ -45,7 +46,7 @@ const lambda = new cf.shortcuts.Lambda({
   Handler: 'guidelines/guidelines-lambda.handler',
   Code: {
     S3Bucket: cf.ref('BucketName'),
-    S3Key: "guidelines.zip",
+    S3Key: 'guidelines.zip',
   },
   Environment: {
     Variables: {

--- a/src/health-leaderboard/cloudformation/health-leaderboard-cfn-template.js
+++ b/src/health-leaderboard/cloudformation/health-leaderboard-cfn-template.js
@@ -4,7 +4,7 @@ const Parameters = {
   BucketName: {
     Type: 'String',
     Description: 'Name of S3 bucket where Lambda code is saved',
-    Default: 'stork-us-east-1',
+    Default: 'slack-bot-commands',
   },
   GitSha: {
     Type: 'String',
@@ -25,7 +25,8 @@ const Resources = {
       ],
       Tags: [
         { Key: 'Name', Value: 'health-leaderboard-sns' },
-        { Key: 'Project', Value: 'slackbot' },
+        { Key: 'Tool', Value: 'slackbot' },
+        { Key: 'Environment', Value: cf.stackName },
       ],
     },
   },
@@ -42,10 +43,10 @@ const Resources = {
 
 const lambda = new cf.shortcuts.Lambda({
   LogicalName: 'HealthLeaderboardLambda',
-  Handler: 'src/health-leaderboard/health-leaderboard-lambda.handler',
+  Handler: 'health-leaderboard/health-leaderboard-lambda.handler',
   Code: {
     S3Bucket: cf.ref('BucketName'),
-    S3Key: cf.join('', ['bundles/slack-bots/', cf.ref('GitSha'), '.zip']),
+    S3Key: 'health-leaderboard.zip',
   },
   Environment: {
     Variables: {

--- a/src/health-tm/cloudformation/health-tm-cfn-template.js
+++ b/src/health-tm/cloudformation/health-tm-cfn-template.js
@@ -4,7 +4,7 @@ const Parameters = {
   BucketName: {
     Type: 'String',
     Description: 'Name of S3 bucket where Lambda code is saved',
-    Default: 'stork-us-east-1',
+    Default: 'slack-bot-commands',
   },
   GitSha: {
     Type: 'String',
@@ -25,7 +25,8 @@ const Resources = {
       ],
       Tags: [
         { Key: 'Name', Value: 'health-tm-sns' },
-        { Key: 'Project', Value: 'slackbot' },
+        { Key: 'Tool', Value: 'slackbot' },
+        { Key: 'Environment', Value: cf.stackName },
       ],
     },
   },
@@ -42,10 +43,10 @@ const Resources = {
 
 const lambda = new cf.shortcuts.Lambda({
   LogicalName: 'HealthTmLambda',
-  Handler: 'src/health-tm/health-tm-lambda.handler',
+  Handler: 'health-tm/health-tm-lambda.handler',
   Code: {
     S3Bucket: cf.ref('BucketName'),
-    S3Key: cf.join('', ['bundles/slack-bots/', cf.ref('GitSha'), '.zip']),
+    S3Key: 'health-tm.zip',
   },
   Environment: {
     Variables: {

--- a/src/new-command/cloudformation/command-name-cfn-template.js
+++ b/src/new-command/cloudformation/command-name-cfn-template.js
@@ -26,7 +26,8 @@ const Resources = {
       ],
       Tags: [
         { Key: 'Name', Value: 'command-name-sns' }, // change to name of command
-        { Key: 'Project', Value: 'slackbot' },
+        { Key: 'Tool', Value: 'slackbot' },
+        { Key: 'Environment', Value: cf.stackName },
       ],
     },
   },

--- a/src/osmcha-stats/cloudformation/osmcha-stats-cfn-template.js
+++ b/src/osmcha-stats/cloudformation/osmcha-stats-cfn-template.js
@@ -4,7 +4,7 @@ const Parameters = {
   BucketName: {
     Type: 'String',
     Description: 'Name of S3 bucket where Lambda code is saved',
-    Default: 'stork-us-east-1',
+    Default: 'slack-bot-commands',
   },
   GitSha: {
     Type: 'String',
@@ -25,7 +25,8 @@ const Resources = {
       ],
       Tags: [
         { Key: 'Name', Value: 'osmcha-stats-sns' },
-        { Key: 'Project', Value: 'slackbot' },
+        { Key: 'Tool', Value: 'slackbot' },
+        { Key: 'Environment', Value: cf.stackName },
       ],
     },
   },
@@ -42,10 +43,10 @@ const Resources = {
 
 const lambda = new cf.shortcuts.Lambda({
   LogicalName: 'OsmChaStatsLambda',
-  Handler: 'src/osmcha-stats/osmcha-stats-lambda.handler',
+  Handler: 'osmcha-stats/osmcha-stats-lambda.handler',
   Code: {
     S3Bucket: cf.ref('BucketName'),
-    S3Key: cf.join('', ['bundles/slack-bots/', cf.ref('GitSha'), '.zip']),
+    S3Key: 'osmcha-stats.zip',
   },
   Environment: {
     Variables: {

--- a/src/tm-stats/cloudformation/tm-stats-cfn-template.js
+++ b/src/tm-stats/cloudformation/tm-stats-cfn-template.js
@@ -4,7 +4,7 @@ const Parameters = {
   BucketName: {
     Type: 'String',
     Description: 'Name of S3 bucket where Lambda code is saved',
-    Default: 'stork-us-east-1',
+    Default: 'slack-bot-commands',
   },
   GitSha: {
     Type: 'String',
@@ -25,7 +25,8 @@ const Resources = {
       ],
       Tags: [
         { Key: 'Name', Value: 'tm-stats-sns' },
-        { Key: 'Project', Value: 'slackbot' },
+        { Key: 'Tool', Value: 'slackbot' },
+        { Key: 'Environment', Value: cf.stackName },
       ],
     },
   },
@@ -42,10 +43,10 @@ const Resources = {
 
 const lambda = new cf.shortcuts.Lambda({
   LogicalName: 'TmStatsLambda',
-  Handler: 'src/tm-stats/tm-stats-lambda.handler',
+  Handler: 'tm-stats/tm-stats-lambda.handler',
   Code: {
     S3Bucket: cf.ref('BucketName'),
-    S3Key: cf.join('', ['bundles/slack-bots/', cf.ref('GitSha'), '.zip']),
+    S3Key: 'tm-stats.zip',
   },
   Environment: {
     Variables: {


### PR DESCRIPTION
What does this PR do?
- Modify the setup of the slack-router and commands so as to be production-ready

Steps taken:
- Move the lambda code for all the slash commands to one S3 bucket. 
- Allow router lambda to publish to SNS topics for the commands
- Update lambda handlers

Partially fixes #36 
